### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json


### PR DESCRIPTION
Please include a `.gitignore` file so that local clones can keep their `git status` clean and not accidentally commit changes for `node_modules/` or `package-lock.json`. Others can be added over time as needed.