### PR TITLE
Checking if Values attribute is valid before checking the lenght of it

### DIFF
--- a/server.js
+++ b/server.js
@@ -29,7 +29,7 @@ router.get('/', function(req, res) {
 router.post('/', function(req, res) {
 	var DWInputValues = req.body;
 	
-	if (DWInputValues.Values.length > 0) {
+	if (DWInputValues.Values && DWInputValues.Values.length > 0) {
 		//call our validations
 		console.log(DWInputValues)
 		validations.checkValues(DWInputValues)


### PR DESCRIPTION
If we call the POST endpoint https://127.0.0.1:4444/api/ without passing values inside the request body the server will return status 500.
- We could have and try/catch validating if the request body is not valid. So we could show a nice message to the user who is trying to call this endpoint.
- We can just check if the DWInputValues.Values is valid. if is not valid just run the code in else statement (line 45).